### PR TITLE
Change type of IResponse.SizeBytes from int to int64 (#559)

### DIFF
--- a/src/NBomber.Contracts/Contracts.fs
+++ b/src/NBomber.Contracts/Contracts.fs
@@ -11,14 +11,14 @@ open NBomber.Contracts.Stats
 type IResponse =
     abstract StatusCode: string
     abstract IsError: bool
-    abstract SizeBytes: int
+    abstract SizeBytes: int64
     abstract LatencyMs: float
     abstract Message: string     
 
 type Response<'T> = {
     StatusCode: string
     IsError: bool
-    SizeBytes: int
+    SizeBytes: int64
     LatencyMs: float
     Message: string
     Payload: 'T option

--- a/src/NBomber.Contracts/Stats.fs
+++ b/src/NBomber.Contracts/Stats.fs
@@ -101,10 +101,10 @@ type DataTransferStats = {
     [<Key 0>] MinBytes: int64
     [<Key 1>] MeanBytes: int64
     [<Key 2>] MaxBytes: int64
-    [<Key 3>] Percent50: int
-    [<Key 4>] Percent75: int
-    [<Key 5>] Percent95: int
-    [<Key 6>] Percent99: int
+    [<Key 3>] Percent50: int64
+    [<Key 4>] Percent75: int64
+    [<Key 5>] Percent95: int64
+    [<Key 6>] Percent99: int64
     [<Key 7>] StdDev: float
     [<Key 8>] AllBytes: int64
 }

--- a/src/NBomber.Contracts/Stats.fs
+++ b/src/NBomber.Contracts/Stats.fs
@@ -98,9 +98,9 @@ type LatencyStats = {
 [<CLIMutable>]
 [<MessagePackObject>]
 type DataTransferStats = {
-    [<Key 0>] MinBytes: int
-    [<Key 1>] MeanBytes: int
-    [<Key 2>] MaxBytes: int
+    [<Key 0>] MinBytes: int64
+    [<Key 1>] MeanBytes: int64
+    [<Key 2>] MaxBytes: int64
     [<Key 3>] Percent50: int
     [<Key 4>] Percent75: int
     [<Key 5>] Percent95: int


### PR DESCRIPTION
This will enable counting data sizes larger than 2 GB.